### PR TITLE
Add new setting 'Keep Popup While Hotkey Held'

### DIFF
--- a/src/meikipop/config/config.py
+++ b/src/meikipop/config/config.py
@@ -30,6 +30,7 @@ class Config:
     _SCHEMA = {
         'Settings': {
             'hotkey': 'shift',
+            'keep_popup_while_hotkey_held': False,
             'scan_region': 'region',
             'max_lookup_length': 25,
             'glens_low_bandwidth': False,

--- a/src/meikipop/gui/input.py
+++ b/src/meikipop/gui/input.py
@@ -182,7 +182,9 @@ class InputLoop(threading.Thread):
 
                 # trigger hit_scans + lookups
                 if current_mouse_pos != last_mouse_pos:
-                    self.shared_state.hit_scan_queue.trigger()
+                    # scar: cancel hotkey if setting & currently pressing (not first check)
+                    if config.keep_popup_while_hotkey_held and not hotkey_is_pressed:
+                        self.shared_state.hit_scan_queue.trigger()
 
                 if hotkey_was_pressed and not hotkey_is_pressed:
                     logger.info(f"Input: Hotkey '{config.hotkey}' released.")

--- a/src/meikipop/gui/popup.py
+++ b/src/meikipop/gui/popup.py
@@ -170,19 +170,19 @@ class Popup(QWidget):
         self._last_latest_data = latest_data
 
         hotkey_down = self.input_loop.is_virtual_hotkey_down()
+        keep_popup_check = config.keep_popup_while_hotkey_held
 
         # scar: check move first, so we don't move twice in the same frame
         mouse_pos = QCursor.pos()
-        if not keep_popup_hk and self.is_visible and hotkey_down:
+        if not keep_popup_check and self.is_visible and hotkey_down:
             self.move_to(mouse_pos.x(), mouse_pos.y())
 
-        keep_popup_hk = config.keep_popup_while_hotkey_held
         if self._latest_data and hotkey_down and config.is_enabled:
             if not self.is_visible:
                 self.show_popup()
                 # scar: move immediately after first check for `keep_popup_hk`
                 self.move_to(QCursor.pos().x(), QCursor.pos().y())
-        elif not (keep_popup_hk and hotkey_down and self.is_visible):
+        elif not (keep_popup_check and hotkey_down and self.is_visible):
             self.hide_popup()
 
     def _render_kanji_entry(self, entry: KanjiEntry):

--- a/src/meikipop/gui/popup.py
+++ b/src/meikipop/gui/popup.py
@@ -169,13 +169,21 @@ class Popup(QWidget):
             self.setFixedSize(new_size)
         self._last_latest_data = latest_data
 
-        if self._latest_data and self.input_loop.is_virtual_hotkey_down() and config.is_enabled:
-            self.show_popup()
-        else:
-            self.hide_popup()
+        hotkey_down = self.input_loop.is_virtual_hotkey_down()
 
+        # scar: check move first, so we don't move twice in the same frame
         mouse_pos = QCursor.pos()
-        self.move_to(mouse_pos.x(), mouse_pos.y())
+        if not keep_popup_hk and self.is_visible and hotkey_down:
+            self.move_to(mouse_pos.x(), mouse_pos.y())
+
+        keep_popup_hk = config.keep_popup_while_hotkey_held
+        if self._latest_data and hotkey_down and config.is_enabled:
+            if not self.is_visible:
+                self.show_popup()
+                # scar: move immediately after first check for `keep_popup_hk`
+                self.move_to(QCursor.pos().x(), QCursor.pos().y())
+        elif not (keep_popup_hk and hotkey_down and self.is_visible):
+            self.hide_popup()
 
     def _render_kanji_entry(self, entry: KanjiEntry):
         # Colors and sizes from config

--- a/src/meikipop/gui/settings_dialog.py
+++ b/src/meikipop/gui/settings_dialog.py
@@ -77,6 +77,11 @@ class SettingsDialog(QDialog):
         self._set_expanding(self.hotkey_combo)
         core_layout.addRow("Hotkey:", self.hotkey_combo)
 
+        self.hold_hotkey_check = QCheckBox()
+        self.hold_hotkey_check.setChecked(config.keep_popup_while_hotkey_held)
+        self.hold_hotkey_check.setToolTip("Keep the popup visible as long as the hotkey is held down")
+        core_layout.addRow("Keep Popup While Hotkey Held:", self.hold_hotkey_check)
+
         self.ocr_provider_combo = QComboBox()
         self.ocr_provider_combo.addItems(self.ocr_processor.available_providers.keys())
         self.ocr_provider_combo.setCurrentText(config.ocr_provider)
@@ -421,6 +426,7 @@ class SettingsDialog(QDialog):
 
         # Update all other config values
         config.hotkey = self.hotkey_combo.currentText()
+        config.keep_popup_while_hotkey_held = self.hold_hotkey_check.isChecked()
         config.glens_low_bandwidth = self.glens_compression_check.isChecked()
         config.max_lookup_length = self.max_lookup_spin.value()
         config.auto_scan_mode = self.auto_scan_check.isChecked()


### PR DESCRIPTION
Heya!~ This pull request adds a new setting to Meikipop to keep the popup open after you hold the hotkey on a word.

**Changes**:
1. Adds new `config.py` option
2. Updates `input.py` with setting check
3. Updates `popup.py` with setting check
4. Adds config option to `settings_dialog.py`

My reasoning for this change was simply because it was a bit frustrating to see dictionary items in specific programs, especially if the text is moving such as games and the like. This fixes that issue by allowing the popup to pause in place.

**Steps to Use**:
1. Enable the setting in the Settings menu
2. Use your 'HotKey' to show the popup
3. Keep holding the hotkey, and the menu will stay in place.

Simple and easy. Love the project, thanks for your work.