### PR TITLE
fix wayland cursor and mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ it is heavily inspired by the philosophy of [Nazeka](https://github.com/wareya/n
 to maintain this focus, there are a few things meikipop is **not**:
 
 *   **it is not an srs-mining tool.** meikipop does not include functionality to automatically create flashcards for programs like anki.
-*   **it is not a multi-dictionary tool.** while meikipops lets you import yomitan dictionaries, it is designed to run best with a single, semi-custom jmdict+kanjidic dictionary. 
+*   **it is not a multi-dictionary tool.** while meikipops lets you import yomitan dictionaries, it is designed to run best with a single, semi-custom jmdict+kanjidic dictionary.
 
 ## installation
 
@@ -38,7 +38,7 @@ just download, unpack and start the executable binary. no python installation re
 
 ### recommended: install via pypi
 
-if you already have python 3.10+ installed, this is the most flexible option that lets you run directly from source, enables you to edit the program and lets you add your own custom ocr providers. 
+if you already have python 3.10+ installed, this is the most flexible option that lets you run directly from source, enables you to edit the program and lets you add your own custom ocr providers.
 
 ```bash
 #... activate your environment if any
@@ -81,13 +81,13 @@ it is possible to run meikipop on wayland in principle, but depending on your sp
 
 here are some tips and recommendations:
 * consider switching to x11
-* the easiest and most compatible way is trying to run the flatpak distribution of meikipop first, before trying any of the other tips 
+* the easiest and most compatible way is trying to run the flatpak distribution of meikipop first, before trying any of the other tips
 * if the flatpak does not work for you, install via pypi or create an editable install and avoid the linux prebuilt, which only got tested on x11
 * make sure you have xwayland working
 * you may need to install additional python dependencies, depending on your system like `pip install pygobject`
 * you may need to install additional os dependencies, depending on your distribution like:
   * fedora: `sudo dnf install libxcb xcb-util xcb-util-cursor libxkbcommon-x11 libxkbcommon xcb-util-wm xcb-util-keysyms pipewire-gstreamer`
-  * ubuntu: `sudo apt install cmake libcairo2-dev libgirepository-2.0-dev libgstreamer1.0-dev gstreamer1.0-pipewire libxcb-xkb-dev libxcb-cursor-dev libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1-dev libxcb-shape0`
+  * ubuntu: `sudo apt install cmake libcairo2-dev libgirepository-2.0-dev libgstreamer1.0-dev gstreamer1.0-pipewire gir1.2-gst-plugins-base-1.0 libxcb-xkb-dev libxcb-cursor-dev libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 libxcb-icccm4 libxcb-keysyms1-dev libxcb-shape0`
 * if meikipop is running, but doesn't show any popups, make sure to test lookups on a windowed xwayland application like steam
 * ask your favorite llm for help
 </details>
@@ -116,7 +116,7 @@ meikipop's architecture allows you to choose whatever ocr suits your use case be
 - google lens (remote): high accuracy, but requires an internet connection and has higher latency then the local options.
 - chrome screen ai (local): alternative local ocr worth checking out if meikiocr does not fit your use case. requires additional setup ([instructions](https://github.com/rtr46/meikipop/releases/tag/v1.10.0))
 - owocr: owocr lets you choose from even more ocr backends (see below)
-- custom ocr provider: if you are running from source it is very simple to integrate any ocr provider on your own (see below) 
+- custom ocr provider: if you are running from source it is very simple to integrate any ocr provider on your own (see below)
 
 ### ...via owocr provider
 
@@ -161,5 +161,3 @@ meikipop import-yomitan-dict-text dict1.zip dict2.zip
 ## license
 
 meikipop is licensed under the GNU General Public License v3.0. see the `LICENSE` file for the full license text.
-
-

--- a/src/meikipop/gui/input.py
+++ b/src/meikipop/gui/input.py
@@ -1,12 +1,15 @@
 # meikipop/gui/input.py
+import fcntl
+import glob
 import logging
+import os
 import sys
 import threading
 import time
 
 from pynput import mouse
 
-from meikipop.config.config import config, IS_LINUX, IS_MACOS
+from meikipop.config.config import config, IS_LINUX, IS_MACOS, IS_WAYLAND
 
 if IS_LINUX:
     from Xlib import display as xlib_display
@@ -20,6 +23,10 @@ else:
 
 
 logger = logging.getLogger(__name__)
+
+_mouse_controller = mouse.Controller()
+if IS_WAYLAND:
+    from meikipop.screenshot.wayland_mss_shim import get_wl_cursor_pos
 
 class LinuxX11KeyboardController:
     def __init__(self, hotkey_str):
@@ -74,6 +81,107 @@ class LinuxX11KeyboardController:
             return True
         except XError:
             return False
+
+
+class LinuxEvdevKeyboardController:
+    EV_KEY = 0x01
+    KEY_MAX = 0x2ff
+    KEY_BITMAP_BYTES = (KEY_MAX + 1) // 8
+
+    KEY_LEFTCTRL = 29
+    KEY_LEFTSHIFT = 42
+    KEY_RIGHTSHIFT = 54
+    KEY_LEFTALT = 56
+    KEY_RIGHTCTRL = 97
+    KEY_RIGHTALT = 100
+
+    KEYCODES = {
+        'shift': (KEY_LEFTSHIFT, KEY_RIGHTSHIFT),
+        'ctrl': (KEY_LEFTCTRL, KEY_RIGHTCTRL),
+        'alt': (KEY_LEFTALT, KEY_RIGHTALT),
+    }
+
+    # _IOC bit layout for reading KEY_BITMAP_BYTES from the E group
+    _IOC_READ = (2 << 30) | (KEY_BITMAP_BYTES << 16) | (ord('E') << 8)
+    # what keys is this device capable of emitting?
+    EVIOCGBIT_EV_KEY = _IOC_READ | (0x20 + EV_KEY)
+    # what keys is this device emitting right now?
+    EVIOCGKEY = _IOC_READ | 0x18
+
+    def __init__(self, hotkey_str):
+        self.fds = []
+        self.modifier_groups = []
+        for key in hotkey_str.lower().split('+'):
+            keycodes = self.KEYCODES.get(key)
+            if not keycodes:
+                logger.critical(f"Unsupported hotkey '{key}' for Linux. Use 'shift', 'ctrl', or 'alt'.")
+                sys.exit(1)
+            self.modifier_groups.append(keycodes)
+        self.fds = self._open_keyboards()
+
+    @classmethod
+    def _open_keyboards(cls):
+        # we're gonna poll over input devices to check for modifier presses,
+        # so strip out all the ones that we are sure cannot emit the keys we want
+        fds = []
+        for path in sorted(glob.glob('/dev/input/event*')):
+            try:
+                fd = os.open(path, os.O_RDONLY)
+            except OSError:
+                continue
+            if cls._reports_modifiers(fd):
+                fds.append(fd)
+            else:
+                os.close(fd)
+        return fds
+
+    @staticmethod
+    def _bit_is_set(bitmap, code):
+        return bool(bitmap[code // 8] >> (code % 8) & 1)
+
+    @classmethod
+    def _reports_modifiers(cls, fd):
+        # keyboards are input devices that have LSHIFT as part of their capability map
+        bitmap = bytearray(cls.KEY_BITMAP_BYTES)
+        try:
+            fcntl.ioctl(fd, cls.EVIOCGBIT_EV_KEY, bitmap)
+        except OSError:
+            return False
+        return cls._bit_is_set(bitmap, cls.KEY_LEFTSHIFT)
+
+    @classmethod
+    def has_readable_devices(cls):
+        fds = cls._open_keyboards()
+        for fd in fds:
+            os.close(fd)
+        return bool(fds)
+
+    def is_hotkey_pressed(self) -> bool:
+        bitmap = bytearray(self.KEY_BITMAP_BYTES)
+        held = bytearray(self.KEY_BITMAP_BYTES)
+        # check whether modifier keys are pressed on any keyboard we have
+        for fd in self.fds:
+            try:
+                fcntl.ioctl(fd, self.EVIOCGKEY, bitmap)
+            except OSError:
+                continue
+            for i in range(self.KEY_BITMAP_BYTES):
+                held[i] |= bitmap[i]
+        for group in self.modifier_groups:
+            if not any(self._bit_is_set(held, code) for code in group):
+                return False
+        return True
+
+    def close(self):
+        for fd in self.fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        self.fds = []
+
+    def __del__(self):
+        self.close()
 
 
 class WindowsKeyboardController:
@@ -134,6 +242,19 @@ class MacOSKeyboardController:
             logger.warning(f"Error checking hotkey state: {e}")
             return False
 
+def make_keyboard_controller(hotkey_str):
+    if IS_LINUX:
+        if IS_WAYLAND:
+            if LinuxEvdevKeyboardController.has_readable_devices():
+                return LinuxEvdevKeyboardController(hotkey_str)
+            logger.warning("No readable devices in /dev/input, the hotkey will only work over "
+                           "XWayland windows. Add your user to the 'input' group and log back in.")
+        return LinuxX11KeyboardController(hotkey_str)
+    if IS_MACOS:
+        return MacOSKeyboardController(hotkey_str)
+    return WindowsKeyboardController(hotkey_str)
+
+
 class InputLoop(threading.Thread):
     def __init__(self, shared_state):
         super().__init__(daemon=True, name="InputLoop")
@@ -141,12 +262,7 @@ class InputLoop(threading.Thread):
         self.mouse_controller = mouse.Controller()
 
         self.hotkey_str = config.hotkey.lower()
-        if IS_LINUX:
-            self.keyboard_controller = LinuxX11KeyboardController(self.hotkey_str)
-        elif IS_MACOS:
-            self.keyboard_controller = MacOSKeyboardController(self.hotkey_str)
-        else: # IS_WINDOWS
-            self.keyboard_controller = WindowsKeyboardController(self.hotkey_str)
+        self.keyboard_controller = make_keyboard_controller(self.hotkey_str)
 
         self.started_auto_mode = False
 
@@ -160,7 +276,7 @@ class InputLoop(threading.Thread):
                 time.sleep(0.1)
                 continue
             try:
-                current_mouse_pos = self.mouse_controller.position
+                current_mouse_pos = self.get_mouse_pos()
                 try:
                     hotkey_is_pressed = self.keyboard_controller.is_hotkey_pressed()
                 except Exception:
@@ -203,16 +319,14 @@ class InputLoop(threading.Thread):
     def reapply_settings(self):
         logger.debug(f"InputLoop: Re-applying settings. New hotkey: '{config.hotkey}'.")
         self.hotkey_str = config.hotkey.lower()
-        if IS_LINUX:
-            self.keyboard_controller = LinuxX11KeyboardController(self.hotkey_str)
-        elif IS_MACOS:
-            self.keyboard_controller = MacOSKeyboardController(self.hotkey_str)
-        else: # IS_WINDOWS
-            self.keyboard_controller = WindowsKeyboardController(self.hotkey_str)
+        self.keyboard_controller = make_keyboard_controller(self.hotkey_str)
 
     @staticmethod
     def get_mouse_pos():
-        with mouse.Controller() as mc:
-            pos = mc.position
-            # Convert floats to integers for QPoint compatibility
-            return (int(pos[0]), int(pos[1]))
+        if IS_WAYLAND:
+            pos = get_wl_cursor_pos()
+            if pos is not None:
+                return pos
+        pos = _mouse_controller.position
+        # Convert floats to integers for QPoint compatibility
+        return (int(pos[0]), int(pos[1]))

--- a/src/meikipop/gui/popup.py
+++ b/src/meikipop/gui/popup.py
@@ -8,8 +8,9 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor, QCursor, QFont, QFontMetrics, QFontInfo
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QFrame, QApplication
 
-from meikipop.config.config import config, IS_MACOS
+from meikipop.config.config import config, IS_MACOS, IS_WAYLAND
 from meikipop.dictionary.lookup import DictionaryEntry, KanjiEntry
+from meikipop.gui.input import InputLoop
 from meikipop.gui.magpie_manager import magpie_manager
 
 # macOS-specific imports for focus management
@@ -174,8 +175,16 @@ class Popup(QWidget):
         else:
             self.hide_popup()
 
-        mouse_pos = QCursor.pos()
+        mouse_pos = self._cursor_pos()
         self.move_to(mouse_pos.x(), mouse_pos.y())
+
+    def _cursor_pos(self):
+        if not IS_WAYLAND:
+            return QCursor.pos()
+        # get_mouse_pos returns physical pixels on Wayland, convert to logical ones for QWidget
+        x, y = InputLoop.get_mouse_pos()
+        ratio = QApplication.primaryScreen().devicePixelRatio()
+        return QPoint(int(x / ratio), int(y / ratio))
 
     def _render_kanji_entry(self, entry: KanjiEntry):
         # Colors and sizes from config

--- a/src/meikipop/screenshot/wayland_mss_shim.py
+++ b/src/meikipop/screenshot/wayland_mss_shim.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import gi
 gi.require_version('Gst', '1.0')
-from gi.repository import GLib, Gst, Gio
+gi.require_version('GstVideo', '1.0')
+from gi.repository import GLib, Gst, GstVideo, Gio
 
 from meikipop.utils.paths import paths
 
@@ -34,6 +35,8 @@ class ScreenCastManager:
     def __init__(self):
         self.screen_cast_iface = 'org.freedesktop.portal.ScreenCast'
         self.frame_lock = threading.Lock()
+        self.cursor_lock = threading.Lock()
+        self.last_cursor = None
         self.selected_event = threading.Event()
         self.ready_event = threading.Event()
         self.request_token_counter = 0
@@ -136,7 +139,7 @@ class ScreenCastManager:
         fd = out_fd_list.get(fd_index)
 
         pipeline_str = (
-            f'pipewiresrc fd={fd} path={node_id} ! '
+            f'pipewiresrc name=pwsrc fd={fd} path={node_id} ! '
             'videoconvert ! '
             'videorate drop-only=true ! '
             'video/x-raw,format={BGRA,BGRx},max-framerate=30/1 ! '
@@ -148,7 +151,20 @@ class ScreenCastManager:
         appsink = self.pipeline.get_by_name('sink')
         appsink.connect('new-sample', self._on_new_sample)
 
+        # grab cursor meta at the source
+        pwsrc = self.pipeline.get_by_name('pwsrc')
+        pwsrc.get_static_pad('src').add_probe(Gst.PadProbeType.BUFFER, self._on_src_buffer)
+
         self.pipeline.set_state(Gst.State.PLAYING)
+
+    def _on_src_buffer(self, pad, info):
+        buffer = info.get_buffer()
+        if buffer is not None:
+            meta = GstVideo.buffer_get_video_region_of_interest_meta_id(buffer, 0)
+            if meta is not None:
+                with self.cursor_lock:
+                    self.last_cursor = (meta.x, meta.y)
+        return Gst.PadProbeReturn.OK
 
     def _on_start_response(self, connection, sender, object_path, interface, signal, parameters):
         response, results = parameters.unpack()
@@ -218,6 +234,7 @@ class ScreenCastManager:
                 'multiple': GLib.Variant('b', False),
                 'types': GLib.Variant('u', 1),
                 'framerate': GLib.Variant('u', 30),
+                'cursor_mode': GLib.Variant('u', 4),
                 'persist_mode': GLib.Variant('u', 2),
                 'restore_token': GLib.Variant('s', persist_token)
             },
@@ -231,10 +248,10 @@ class ScreenCastManager:
 
     def _initialize_screencast(self):
         Gst.init(None)
-        
+
         context = GLib.MainContext.new()
         context.push_thread_default()
-        
+
         try:
             self.loop = GLib.MainLoop.new(context)
             self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
@@ -259,7 +276,7 @@ class ScreenCastManager:
             raise ScreenShotError(f'Error initializing screencast: {e}')
         finally:
             context.pop_thread_default()
-            
+
     def request_frame(self):
         if self.ready_event.is_set():
             with self.frame_lock:
@@ -267,11 +284,18 @@ class ScreenCastManager:
                     return self.last_frame
         return (None, 0, 0)
 
+    def request_cursor(self):
+        if self.ready_event.is_set():
+            with self.cursor_lock:
+                return self.last_cursor
+        return None
+
     def start(self):
         self.pipeline = None
         self.loop = None
         self.session = None
         self.last_frame = None
+        self.last_cursor = None
         self.selected_event.clear()
 
         self.init_thread = threading.Thread(target=self._initialize_screencast, daemon=True)
@@ -382,3 +406,9 @@ class MSSModuleShim:
 
     def __getattr__(self, name):
         return getattr(real_mss, name)
+
+
+def get_wl_cursor_pos():
+    if not screencast:
+        return None
+    return screencast.request_cursor()


### PR DESCRIPTION
moved `cursor_mode` when creating the portal session from 1 (hidden) to 4 (metadata), which attaches the cursor position through the pipewire pipeline, at which point we can grab it in `_play_pipewire_stream()`. From there I put it on `last_cursor` in the wayland shim and it's available downstream. There's an extra `gir1.2-gst-plugins-base-1.0` needed on Ubuntu at least, dunno what it is on Fedora or whether some other files need to be changed for the flatpak to add that one...

I also added an Evdev backend for requesting keyboard input, which reads input directly from the kernel interface. Implemented the fd querying and bit logic directly rather than using an external lib since `python-evdev` links against C code and has no wheels, so it'd be a buncha extra dependencies for a few bit shifts, and it's 100 lines of code for the whole thing anyway. The current user needs to be in the `input` group for this to work, and if using flatpak, `--device=input` needs to be passed as well, so that needs a mention somewhere in the readme.

Other than, I only did a small optimization by moving the initialization of `mouse.Controller()` out of the `get_mouse_pos()` input loop.

This allows meikipop to process any wayland window for me and activate only on modifier key press if the option is enabled (Mutter, Gnome, but I imagine it should work fine for anything that uses portals). Haven't tested Flatpak with this but should work in theory.